### PR TITLE
PK iteration 1

### DIFF
--- a/draft-turner-lamps-nist-pqc-kem-certificates.md
+++ b/draft-turner-lamps-nist-pqc-kem-certificates.md
@@ -27,7 +27,7 @@ author:
 normative:
 
 informative:
-  PQCComp:
+  PQCProj:
     target: https://csrc.nist.gov/projects/post-quantum-cryptography
     title: Post-Quantum Cryptography Project
     author:
@@ -47,8 +47,8 @@ encoding for public key and private key is also provided.
 
 # Introduction
 
-The US NIST PQC competition has selected the Candidate TBD1 
-algorithms as winners of their PQC competition {{PQCComp}}. These
+The US NIST PQC Project has selected the Candidate TBD1 
+algorithms as winners of their PQC Project {{PQCProj}}. These
 algorithms are KEM algorithms. NIST has also defined object identifiers
 for these algorithms (TODO insert reference).
 

--- a/draft-turner-lamps-nist-pqc-kem-certificates.md
+++ b/draft-turner-lamps-nist-pqc-kem-certificates.md
@@ -108,7 +108,12 @@ that subsystem and not propagated to the Internet.
 
 TODO insert object-identifiers
 
-
+The identifiers defined in this section can be used as the
+AlgorithmIdentifier in the signatureAlgorithm field in the
+sequence Certificate and the signature field in the sequence
+TBSCertificate in X.509 {{RFC5280}}. The parameters of these
+signature algorithms are absent. 
+   
 
 # Subject Public Key Fields
 

--- a/draft-turner-lamps-nist-pqc-kem-certificates.md
+++ b/draft-turner-lamps-nist-pqc-kem-certificates.md
@@ -40,19 +40,19 @@ informative:
 This document specifies algorithm identifiers and ASN.1 encoding format
 for the US NIST's PQC KEM (United States National Institute of Standards
 and Technology's Post Quantum Cryptography Key Encapsulation Mechanism)
-algorithms. The algorithms covered are Candidate 1 and Candidate 2. The
+algorithms. The algorithms covered are Candidate TBD1. The
 encoding for public key and private key is also provided.
 
 --- middle
 
 # Introduction
 
-The US NIST PQC competition has selected the Candidate 1 and Candidate 2
+The US NIST PQC competition has selected the Candidate TBD1 
 algorithms as winners of their PQC competition {{PQCComp}}. These
 algorithms are KEM algorithms. NIST has also defined object identifiers
 for these algorithms (TODO insert reference).
 
-This document specifies the use of the Candidate 1 and Candidate 2
+This document specifies the use of the Candidate TBD1 
 algorithms in X.509 public key certifiates, see {{!RFC5280}}. It also
 specifies private key encoding. An ASN.1 module is included for
 reference purposes.
@@ -87,8 +87,7 @@ copmatible with the 2015 ASN.1 syntax.
 The fields in AlgorithmIdentifier have the following meanings:
 
 * algorithm identifies the cryptographic algorithm with an object
-  identifier. XXX such OIDs are defined in Sections {{candidate-1}} and
-  {{candidate-2}}.
+  identifier. XXX such OIDs are defined in Sections {{candidate-TBD1}}.
 
 * parameters, which are optional, are the associated parameters for
   the algorithm identifier in the algorithm field.
@@ -105,14 +104,11 @@ where this is not possible, the problem needs to be restricted to
 that subsystem and not propagated to the Internet.
 
 
-# Candidate 1 {#candidate-1}
+# Candidate TBD1 {#candidate-1}
 
 TODO insert object-identifiers
 
 
-# Candidate 2 {#candidate-2}
-
-TODO insert object identifiers
 
 # Subject Public Key Fields
 
@@ -156,7 +152,7 @@ The intended application for the key is indicated in the keyUsage
 certificate extension; see {{Section 4.2.1.3 of RFC5280}}.
 
 If the keyUsage extension is present in a certificate that indicates
-Candidate 1 or Candidate 2 in SubjectPublicKeyInfo, then the following
+Candidate TBD1 in SubjectPublicKeyInfo, then the following
 MUST be present:
 
 ~~~

--- a/draft-turner-lamps-nist-pqc-kem-certificates.md
+++ b/draft-turner-lamps-nist-pqc-kem-certificates.md
@@ -61,6 +61,14 @@ subjectPublicKeyInfo fields within Internet X.509 certificates
 It also specifies private key encoding. 
 An ASN.1 module is included for reference purposes.
 
+These certificates could be used as Issuers in CMS where the public key 
+is used to encapsulate a shared secret used to derive a symmetric key 
+used to encrypt content in CMS 
+\[EDNOTE: Add reference draft-perret-prat-lamps-cms-pq-kem\]. 
+To be used in TLS, these certificates could only be used as end-entity 
+identity certificates and would require significant updates to the
+protocol 
+\[EDNOTE: Add reference draft-celi-wiggers-tls-authkem\]. 
 
 # Conventions and Definitions
 
@@ -111,12 +119,6 @@ that subsystem and not propagated to the Internet.
 # Candidate TBD1 {#candidate-1}
 
 TODO insert object-identifiers
-
-The identifiers defined in this section can be used as the
-AlgorithmIdentifier in the signatureAlgorithm field in the
-sequence Certificate and the signature field in the sequence
-TBSCertificate in X.509 {{RFC5280}}. The parameters of these
-signature algorithms are absent. 
    
 
 # Subject Public Key Fields

--- a/draft-turner-lamps-nist-pqc-kem-certificates.md
+++ b/draft-turner-lamps-nist-pqc-kem-certificates.md
@@ -53,9 +53,13 @@ algorithms are KEM algorithms. NIST has also defined object identifiers
 for these algorithms (TODO insert reference).
 
 This document specifies the use of the Candidate TBD1 
-algorithms in X.509 public key certifiates, see {{!RFC5280}}. It also
-specifies private key encoding. An ASN.1 module is included for
-reference purposes.
+algorithms in X.509 public key certifiates, see {{!RFC5280}}. 
+More specifically. it defines additional content for the
+signatureAlgorithm, signatureValue, signature, and
+subjectPublicKeyInfo fields within Internet X.509 certificates
+{{RFC3279}} and CRLs {{RFC5280}}. 
+It also specifies private key encoding. 
+An ASN.1 module is included for reference purposes.
 
 
 # Conventions and Definitions

--- a/draft-turner-lamps-nist-pqc-kem-certificates.md
+++ b/draft-turner-lamps-nist-pqc-kem-certificates.md
@@ -54,10 +54,6 @@ for these algorithms (TODO insert reference).
 
 This document specifies the use of the Candidate TBD1 
 algorithms in X.509 public key certifiates, see {{!RFC5280}}. 
-More specifically. it defines additional content for the
-signatureAlgorithm, signatureValue, signature, and
-subjectPublicKeyInfo fields within Internet X.509 certificates
-{{RFC3279}} and CRLs {{RFC5280}}. 
 It also specifies private key encoding. 
 An ASN.1 module is included for reference purposes.
 


### PR DESCRIPTION
Minor changes 
- Remove Candidate 2 and made Candidate 1 to TBD1, just for simplicity reasons.
- Rephrased PQ Competition to PQ Project because NIST did not want to call it a Competion
- Added text about the uses of these certs that include PQ KEMs as public keys.